### PR TITLE
Fix issues with out-of-sync light lists

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -4,6 +4,7 @@
 max-line-length = 88
 exclude =
     __pycache__,
+    .eggs,
     build,
     scripts,
     docs

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 MANIFEST
 dist/
 elgato.egg-info/
+.eggs/

--- a/elgato/__main__.py
+++ b/elgato/__main__.py
@@ -42,7 +42,9 @@ class Discovered:
     def __init__(self, path: str) -> None:
         """Initialize with a path to a JSON file."""
         self.path = path
-        with open(path) as f:
+
+    def hydrate(self) -> None:
+        with open(self.path) as f:
             lights: List[DiscoveredLight] = json.loads(f.read())
             ok = True
             for (i, light) in enumerate(lights):
@@ -129,6 +131,8 @@ def lights(discover: bool) -> int:
     """Discover the lights on the network, and display them."""
     if discover:
         discovered.refresh()
+    else:
+        discovered.hydrate()
 
     for index in range(len(discovered.lights)):
         print(f"Light {index}")
@@ -139,6 +143,7 @@ def lights(discover: bool) -> int:
 
 def turn_on(which: int) -> int:
     """Turn on the requested light."""
+    discovered.hydrate()
     light = discovered.get_light(which)
     light.on()
     return 0
@@ -146,6 +151,7 @@ def turn_on(which: int) -> int:
 
 def turn_off(which: int) -> int:
     """Turn off the requested light."""
+    discovered.hydrate()
     light = discovered.get_light(which)
     light.off()
     return 0
@@ -153,6 +159,7 @@ def turn_off(which: int) -> int:
 
 def toggle(which: int) -> int:
     """Toggle the requested light."""
+    discovered.hydrate()
     light = discovered.get_light(which)
     return turn_on(which) if light.isOn == 0 else turn_off(which)
 
@@ -161,6 +168,7 @@ def set_color(
     which: int, level: Optional[int], warmer: Optional[int], cooler: Optional[int]
 ) -> int:
     """Set the first light's color temperature."""
+    discovered.hydrate()
     light = discovered.get_light(which)
 
     delta: Optional[int] = None
@@ -190,6 +198,7 @@ def set_brightness(
     which: int, level: Optional[int], brighter: Optional[int], dimmer: Optional[int]
 ) -> int:
     """Set the first light's brightness."""
+    discovered.hydrate()
     light = discovered.get_light(which)
 
     delta: Optional[int] = None

--- a/elgato/__main__.py
+++ b/elgato/__main__.py
@@ -5,7 +5,7 @@ import json
 import leglight
 import os
 import sys
-from typing import List, Literal, Optional, TypedDict
+from typing import Any, List, Literal, Optional, TypedDict
 
 
 # Monkeypatch requests to provide a timeout for all GET requests.
@@ -14,7 +14,7 @@ import requests
 old_get = requests.get
 
 
-def new_get(*args, **kwargs):
+def new_get(*args: Any, **kwargs: Any) -> Any:
     """Wrap calls to requests.get() with injection of a timeout."""
     kwargs["timeout"] = 2
     return old_get(*args, **kwargs)

--- a/elgato/__main__.py
+++ b/elgato/__main__.py
@@ -8,6 +8,15 @@ import sys
 from typing import List, Literal, Optional, TypedDict
 
 
+# Monkeypatch requests to provide a timeout for all GET requests.
+import requests
+old_get = requests.get
+def new_get(*args, **kwargs):
+    kwargs["timeout"] = 2
+    return old_get(*args, **kwargs)
+requests.get = new_get
+
+
 class DiscoveredLight(TypedDict):
     """Type of persisted light information."""
 


### PR DESCRIPTION
This PR solves the problem of the software crashing or hanging when the list of lights goes out of sync with reality.

Now, as the lights in the saved list are constructed, any failures are reported, with a suggestion to re-run light discovery. The issue of hanging (or other network request failures) is solved somewhat inelegantly by forcing a two-second timeout on all GET requests via a monkeypatch on the `requests` module.

This PR also delays the construction of the discovered light list until it is needed.

Closes #15.