### PR TITLE
Invert the behavior of `--warmer` and `--cooler`

### DIFF
--- a/elgato/__main__.py
+++ b/elgato/__main__.py
@@ -191,9 +191,9 @@ def set_color(
     if level is not None:
         light.color(level)
     elif warmer is not None:
-        delta = 500 if warmer < 0 else warmer
+        delta = -500 if warmer < 0 else -warmer
     elif cooler is not None:
-        delta = -500 if cooler < 0 else -cooler
+        delta = 500 if cooler < 0 else cooler
     else:
         print(int(light.isTemperature))
 


### PR DESCRIPTION
As pointed out by @ubald, in colorimetry "cooler" means "more bluish"
and "warmer" means "more reddish", contrary to the black body radiation
usage of temperature terms. This commit simply inverts the behavior of
the two terms to match usage in colorimetry.

Closes #18 